### PR TITLE
Removed dependency on sysctl

### DIFF
--- a/src/netroute.cc
+++ b/src/netroute.cc
@@ -5,7 +5,6 @@
 #include <errno.h>
 #include <sys/types.h>
 #include <sys/socket.h>
-#include <sys/sysctl.h>
 #include <net/if.h>
 #include <net/route.h>
 


### PR DESCRIPTION
This system call no longer exists on current kernels. See: https://man7.org/linux/man-pages/man2/sysctl.2.html Prevents building on fedora 33. Fails with error:
```make: Entering directory '/home/saleemabdulhamid/Employment/Software/Consulting/wave-master/node_modules/netroute/build'
  CXX(target) Release/obj.target/netroute/src/netroute.o
../src/netroute.cc:8:10: fatal error: sys/sysctl.h: No such file or directory
    8 | #include <sys/sysctl.h>
      |          ^~~~~~~~~~~~~~
compilation terminated.
```

Builds and works fine without it.